### PR TITLE
Uri prefix support

### DIFF
--- a/opsy.toml.example
+++ b/opsy.toml.example
@@ -13,6 +13,11 @@ database_uri = 'sqlite:///../opsy.db'
 # Required: true
 secret_key = 'this is a secret'
 
+# This is used if Opsy is behind a reverse proxy. It should be set to where
+# you have it mounted, like '/opsy/' for example.
+# Required: false
+application_root = '/'
+
 [server]
 # This section contains configuration for the embedded WSGI server.
 

--- a/opsy.toml.example
+++ b/opsy.toml.example
@@ -14,9 +14,10 @@ database_uri = 'sqlite:///../opsy.db'
 secret_key = 'this is a secret'
 
 # This is used if Opsy is behind a reverse proxy. It should be set to where
-# you have it mounted, like '/opsy/' for example.
+# you have it mounted, like '/opsy' for example.
 # Required: false
-application_root = '/'
+# Default value: /
+uri_prefix = '/'
 
 [server]
 # This section contains configuration for the embedded WSGI server.

--- a/opsy/app.py
+++ b/opsy/app.py
@@ -7,9 +7,26 @@ from opsy.auth.views import create_auth_views
 from opsy.inventory.views import create_inventory_views
 
 
+class PrefixMiddleware:
+
+    def __init__(self, app, prefix=''):
+        self.app = app
+        self.prefix = prefix
+
+    def __call__(self, environ, start_response):
+        if environ['PATH_INFO'].startswith(self.prefix):
+            environ['PATH_INFO'] = environ['PATH_INFO'][len(self.prefix):]
+            environ['SCRIPT_NAME'] = self.prefix
+            return self.app(environ, start_response)
+        start_response('404', [('Content-Type', 'text/plain')])
+        return ["This url does not belong to the app.".encode()]
+
+
 def create_app(config):
     configure_logging(config)
     app = Flask('opsy')
+    app.wsgi_app = PrefixMiddleware(
+        app.wsgi_app, prefix=config['app']['uri_prefix'])
     app.before_request(log_before_request)
     app.after_request(log_after_request)
     configure_app(app, config)

--- a/opsy/config.py
+++ b/opsy/config.py
@@ -8,7 +8,7 @@ from opsy.exceptions import NoConfigFile
 class ConfigAppSchema(Schema):
     database_uri = fields.Str(required=True)
     secret_key = fields.Str(required=True)
-    application_root = fields.Str(missing='/')
+    uri_prefix = fields.Str(missing='/')
 
 
 class ConfigAuthSchema(Schema):
@@ -98,7 +98,6 @@ def configure_app(app, config):
         'JSON_SORT_KEYS': False,
         'SECRET_KEY': config['app']['secret_key'],
         'SQLALCHEMY_DATABASE_URI': config['app']['database_uri'],
-        'APPLICATION_ROOT': config['app']['application_root'],
         'LDAP_HOST': config['auth']['ldap_host'],
         'LDAP_PORT': config['auth']['ldap_port'],
         'LDAP_USE_SSL': config['auth']['ldap_use_ssl'],

--- a/opsy/config.py
+++ b/opsy/config.py
@@ -8,6 +8,7 @@ from opsy.exceptions import NoConfigFile
 class ConfigAppSchema(Schema):
     database_uri = fields.Str(required=True)
     secret_key = fields.Str(required=True)
+    application_root = fields.Str(missing='/')
 
 
 class ConfigAuthSchema(Schema):
@@ -97,6 +98,7 @@ def configure_app(app, config):
         'JSON_SORT_KEYS': False,
         'SECRET_KEY': config['app']['secret_key'],
         'SQLALCHEMY_DATABASE_URI': config['app']['database_uri'],
+        'APPLICATION_ROOT': config['app']['application_root'],
         'LDAP_HOST': config['auth']['ldap_host'],
         'LDAP_PORT': config['auth']['ldap_port'],
         'LDAP_USE_SSL': config['auth']['ldap_use_ssl'],

--- a/opsy/flask_extensions.py
+++ b/opsy/flask_extensions.py
@@ -42,7 +42,8 @@ def configure_extensions(app):
             version='v1',
             openapi_version='2.0',
             info={'description': "It's Opsy!"},
-            plugins=[MarshmallowPlugin()]
+            plugins=[MarshmallowPlugin()],
+            basePath=app.config.opsy['app']['uri_prefix']
         ),
         'APISPEC_SWAGGER_URL': '/docs/swagger.json',
         'APISPEC_SWAGGER_UI_URL': '/docs/',

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -11,7 +11,7 @@ cat > ${OPSY_CONFIG} <<__EOF__
 [app]
 database_uri = '${OPSY_DATABASE_URI}'
 secret_key = '${OPSY_SECRET_KEY}'
-application_root = '${OPSY_APPLICATION_ROOT:-/}'
+uri_prefix = '${OPSY_URI_PREFIX:-/}'
 
 [server]
 host = '0.0.0.0'

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -11,6 +11,7 @@ cat > ${OPSY_CONFIG} <<__EOF__
 [app]
 database_uri = '${OPSY_DATABASE_URI}'
 secret_key = '${OPSY_SECRET_KEY}'
+application_root = '${OPSY_APPLICATION_ROOT:-/}'
 
 [server]
 host = '0.0.0.0'

--- a/tests/schema/test_auth.py
+++ b/tests/schema/test_auth.py
@@ -70,11 +70,23 @@ def test_user_schema(test_user):
         ('created_at', test_user.created_at.isoformat()),
         ('updated_at', test_user.updated_at.isoformat()),
         ('roles', [
-            OrderedDict([('id', x.id), ('name', x.name)])
+            OrderedDict([
+                ('id', x.id),
+                ('name', x.name),
+                ('_links', {
+                    'self': f'/api/v1/roles/{x.id}',
+                    'collection': '/api/v1/roles/'})])
             for x in test_user.roles]),
-        ('permissions', [
-            OrderedDict([('id', x.id), ('name', x.name)])
-            for x in test_user.permissions])])
+        ('permissions', [OrderedDict([
+            ('id', x.id),
+            ('name', x.name),
+            ('_links', {
+                'self': f'/api/v1/roles/{x.role.id}/permissions/{x.id}',
+                'collection': f'/api/v1/roles/{x.role.id}/permissions/'})])
+            for x in test_user.permissions]),
+        ('_links', {
+            'self': f'/api/v1/users/{test_user.id}',
+            'collection': '/api/v1/users/'})])
 
     assert UserSchema().dump(test_user) == expected_user_schema_output
 
@@ -114,10 +126,17 @@ def test_role_schema(test_role):
         ('description', test_role.description),
         ('created_at', test_role.created_at.isoformat()),
         ('updated_at', test_role.updated_at.isoformat()),
-        ('permissions', [
-            OrderedDict([('id', x.id), ('name', x.name)])
+        ('permissions', [OrderedDict([
+            ('id', x.id),
+            ('name', x.name),
+            ('_links', {
+                'self': f'/api/v1/roles/{x.role.id}/permissions/{x.id}',
+                'collection': f'/api/v1/roles/{x.role.id}/permissions/'})])
             for x in test_role.permissions]),
-        ('users', test_role.users)])
+        ('users', test_role.users),
+        ('_links', {
+            'self': f'/api/v1/roles/{test_role.id}',
+            'collection': '/api/v1/roles/'})])
 
     assert RoleSchema().dump(test_role) == expected_role_schema_output
 
@@ -135,10 +154,16 @@ def test_role_permission_schema(admin_user):
         ('id', test_perm.id),
         ('role', OrderedDict([
             ('id', test_perm.role.id),
-            ('name', test_perm.role.name)])),
+            ('name', test_perm.role.name),
+            ('_links', {
+                'self': f'/api/v1/roles/{test_perm.role.id}',
+                'collection': '/api/v1/roles/'})])),
         ('name', test_perm.name),
         ('created_at', test_perm.created_at.isoformat()),
-        ('updated_at', test_perm.updated_at.isoformat())])
+        ('updated_at', test_perm.updated_at.isoformat()),
+        ('_links', {
+            'self': f'/api/v1/roles/{test_perm.role.id}/permissions/{test_perm.id}',
+            'collection': f'/api/v1/roles/{test_perm.role.id}/permissions/'})])
 
     assert RolePermissionSchema().dump(test_perm) \
         == expected_role_permission_schema_output


### PR DESCRIPTION
Added support for specifying a URI prefix for cases when Opsy is behind
a reverse proxy.

Added _links references to auth schema, seems this was forgotten about
when the auth API was created. Updated tests to reflect this