### PR TITLE
Add CI for helm testing and packaging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,11 +154,13 @@ commands:
           command: |
             virtualenv ~/venv
             . ~/venv/bin/activate
-            pip install tox
+            pip install --upgrade pip setuptools wheel
+            pip install --upgrade tox
             tox --notest
             echo "source ~/venv/bin/activate" >> $BASH_ENV
       - save_cache:
           paths:
+            - ~/venv
             - ~/repo/.tox
           key: v1-dependencies-<< parameters.python_version >>-{{ checksum "requirements.txt" }}-{{ checksum "test-requirements.txt" }}
   setup_helm:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,7 +224,7 @@ commands:
             echo "source ~/venv/bin/activate" >> $BASH_ENV
       - run:
           name: Load docker image from workspace
-          command: cat dist/Opsy-${CIRCLE_TAG}-docker.tar.gz | gzip -d | docker image load
+          command: cat dist/docker/Opsy-${CIRCLE_TAG}-docker.tar.gz | gzip -d | docker image load
       - run:
           name: Push python and docker release
           command: make release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,6 +126,7 @@ jobs:
       - image: circleci/python:3.6
     working_directory: ~/repo
     steps:
+      - setup_helm
       - build
   release:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,17 +9,25 @@ workflows:
   # This will run on every commit, but not on tags.
   test_build:
     jobs:
+      - test_style
       - test_python36
       - test_python37
       - test_python38
       - build:
           requires:
+            - test_style
             - test_python36
             - test_python37
             - test_python38
   # This will run only on tagged commits due to the filters.
   test_build_release:
     jobs:
+      - test_style:
+          filters:
+            tags:
+              only: /[0-9]+(\.[0-9]+)*(\.0(a|b|rc)[0-9]*)?/
+            branches:
+              ignore: /.*/
       - test_python36:
           filters:
             tags:
@@ -45,6 +53,7 @@ workflows:
             branches:
               ignore: /.*/
           requires:
+            - test_style
             - test_python36
             - test_python37
             - test_python38
@@ -67,6 +76,15 @@ workflows:
             - hold
 
 jobs:
+  test_style:
+    docker:
+      - image: circleci/python:3.6
+    working_directory: ~/repo
+    steps:
+      - setup_tox:
+          python_version: "3.6"
+      - setup_helm
+      - test_style
   test_python36:
     docker:
       - image: circleci/python:3.6
@@ -76,9 +94,9 @@ jobs:
           POSTGRES_DB: opsy
     working_directory: ~/repo
     steps:
-      - common_setup:
+      - setup_tox:
           python_version: "3.6"
-      - run_tests
+      - test_code
   test_python37:
     docker:
       - image: circleci/python:3.7
@@ -88,9 +106,9 @@ jobs:
           POSTGRES_DB: opsy
     working_directory: ~/repo
     steps:
-      - common_setup:
+      - setup_tox:
           python_version: "3.7"
-      - run_tests
+      - test_code
   test_python38:
     docker:
       - image: circleci/python:3.8
@@ -100,9 +118,9 @@ jobs:
           POSTGRES_DB: opsy
     working_directory: ~/repo
     steps:
-      - common_setup:
+      - setup_tox:
           python_version: "3.8"
-      - run_tests
+      - test_code
   build:
     docker:
       - image: circleci/python:3.6
@@ -117,8 +135,8 @@ jobs:
       - release
 
 commands:
-  common_setup:
-    description: Common steps for all jobs
+  setup_tox:
+    description: Install tox and load its cache
     parameters:
       python_version:
           type: string
@@ -141,12 +159,28 @@ commands:
           paths:
             - ~/repo/.tox
           key: v1-dependencies-<< parameters.python_version >>-{{ checksum "requirements.txt" }}-{{ checksum "test-requirements.txt" }}
-  run_tests:
-    description: Run tests
+  setup_helm:
+    description: Install helm
     steps:
       - run:
-          name: Run tests
-          command: make test
+          name: Install Helm binaries
+          command: |
+            curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get | bash -s -- -v v2.16.1
+      - run:
+          name: Init Helm
+          command: helm init --client-only
+  test_style:
+    description: Run style checks
+    steps:
+      - run:
+          name: Run style checks
+          command: make test-style
+  test_code:
+    description: Run python tests
+    steps:
+      - run:
+          name: Run python tests
+          command: make test-code
   build:
     description: Build the python package and docker image
     steps:
@@ -169,9 +203,6 @@ commands:
                 echo "No tag, stopping build early."
                 circleci-agent step halt
             fi
-      - run:
-          name: Save docker image to workspace
-          command: docker save objectrocket/opsy:${CIRCLE_TAG} | gzip > dist/Opsy-${CIRCLE_TAG}-docker.tar.gz
       - persist_to_workspace:
           root: dist
           paths: '*'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,6 +133,7 @@ jobs:
       - image: circleci/python:3.6
     working_directory: ~/repo
     steps:
+      - setup_helm
       - release
 
 commands:
@@ -225,5 +226,22 @@ commands:
           name: Load docker image from workspace
           command: cat dist/Opsy-${CIRCLE_TAG}-docker.tar.gz | gzip -d | docker image load
       - run:
-          name: Push release
+          name: Push python and docker release
           command: make release
+      - add_ssh_keys:
+          fingerprints:
+            - "fc:74:39:48:d3:a0:a2:7c:71:45:58:cf:bf:5b:7e:8a"
+      - run:
+          name: Push helm chart release
+          command: |
+            export CHART_VERSION="$(egrep '^version:' helm/opsy/Chart.yaml | sed 's/^version: \(.*\)$/\1/')+${CIRCLE_TAG}"
+            git config --global user.email "builds@circleci.com"
+            git config --global user.name "CircleCI"
+            git checkout gh-pages
+            cp dist/helm/opsy-${CHART_VERSION}.tgz helm/
+            cd helm/
+            helm repo index .
+            git add opsy-${CHART_VERSION}.tgz
+            git add index.yaml
+            git commit -m "[ci skip] Release ${CIRCLE_TAG}."
+            git push origin gh-pages

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,3 @@
 *
 !scripts/entrypoint.sh
-!dist/Opsy-*-py3-none-any.whl
+!dist/python/Opsy-*-py3-none-any.whl

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN useradd -rmd /opt/opsy opsy
 
 USER opsy
 
-COPY --chown=opsy:opsy dist/Opsy-${OPSY_VERSION}-py3-none-any.whl /opt/opsy
+COPY --chown=opsy:opsy dist/python/Opsy-${OPSY_VERSION}-py3-none-any.whl /opt/opsy
 
 RUN set -ex; \
     python -m venv /opt/opsy && \

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 RELEASE_VERSION := $(shell git describe --exact-match --tags $$(git log -n1 --pretty='%h') 2> /dev/null)
 PACKAGE_VERSION := $(shell python setup.py --version 2> /dev/null)
+CHART_VERSION := $(shell egrep '^version:' helm/opsy/Chart.yaml | sed 's/^version: \(.*\)$$/\1/')+$(PACKAGE_VERSION)
+
+# Utility targets
+.PHONY: default versions clean clean-tests install
 
 default: build
 
@@ -7,6 +11,7 @@ versions:
 	# Just prints out the detected versions based on setuptools and git tags.
 	@echo PACKAGE_VERSION=$(PACKAGE_VERSION)
 	@echo RELEASE_VERSION=$(RELEASE_VERSION)
+	@echo CHART_VERSION=$(CHART_VERSION)
 
 clean:
 	python setup.py clean
@@ -15,38 +20,64 @@ clean:
 clean-tests:
 	rm -rf .tox/
 
-build-requirements:
-	pip install --upgrade -r build-requirements.txt
-
-build-wheel:
-	python setup.py sdist bdist_wheel
-
-build-docker:
-	docker build -t objectrocket/opsy:$(PACKAGE_VERSION) --build-arg OPSY_VERSION=$(PACKAGE_VERSION) .
-
-build-test:
-	# Make sure our files are named correctly
-	test -s dist/Opsy-$(PACKAGE_VERSION)-py3-none-any.whl
-	test -s dist/Opsy-$(PACKAGE_VERSION).tar.gz
-	# Run twine checks
-	twine check dist/Opsy-$(PACKAGE_VERSION)-py3-none-any.whl dist/Opsy-$(PACKAGE_VERSION).tar.gz
-
-build: build-requirements clean build-wheel build-docker build-test
-
 install:
 	pip install -e .
 
-test:
-	tox
 
-release-test:
+# Test targets
+.PHONY: test-code test-style test-build test-release test
+
+test-code:
+	tox -e code
+
+test-style:
+	tox -e style
+	helm lint helm/opsy/
+
+test-build:
+	# Make sure our files are named correctly
+	test -s dist/python/Opsy-$(PACKAGE_VERSION)-py3-none-any.whl
+	test -s dist/python/Opsy-$(PACKAGE_VERSION).tar.gz
+	# Run twine checks
+	twine check dist/python/Opsy-$(PACKAGE_VERSION)-py3-none-any.whl dist/python/Opsy-$(PACKAGE_VERSION).tar.gz
+	# Check helm build
+	helm lint dist/helm/opsy-$(CHART_VERSION).tgz
+
+test-release:
 	# Make sure package version matches git tag.
 	test "$(RELEASE_VERSION)" = "$(PACKAGE_VERSION)"
 	# Make sure our files are named correctly
-	test -s dist/Opsy-$(RELEASE_VERSION)-py3-none-any.whl
-	test -s dist/Opsy-$(RELEASE_VERSION).tar.gz
+	test -s dist/python/Opsy-$(RELEASE_VERSION)-py3-none-any.whl
+	test -s dist/python/Opsy-$(RELEASE_VERSION).tar.gz
 	# Run twine checks
-	twine check dist/Opsy-$(RELEASE_VERSION)-py3-none-any.whl dist/Opsy-$(RELEASE_VERSION).tar.gz
+	twine check dist/python/Opsy-$(RELEASE_VERSION)-py3-none-any.whl dist/python/Opsy-$(RELEASE_VERSION).tar.gz
+
+test: test-code test-style
+
+
+# Build targets
+.PHONY: build-requirements build-python build-docker build-helm build
+build-requirements:
+	pip install --upgrade -r build-requirements.txt
+
+build-python:
+	mkdir -p dist/python/
+	python setup.py sdist -d dist/python bdist_wheel -d dist/python
+
+build-docker:
+	mkdir -p dist/docker/
+	docker build -t objectrocket/opsy:$(PACKAGE_VERSION) --build-arg OPSY_VERSION=$(PACKAGE_VERSION) .
+	docker save objectrocket/opsy:$(PACKAGE_VERSION) | gzip > dist/docker/Opsy-$(PACKAGE_VERSION).tar.gz
+
+build-helm:
+	mkdir -p dist/helm/
+	helm package helm/opsy/ -d dist/helm/ --app-version $(PACKAGE_VERSION) --version $(CHART_VERSION)
+
+build: build-requirements clean build-python build-docker build-helm test-build
+
+
+# Release targets
+.PHONY: release-dockerhub release-pypi release
 
 release-dockerhub:
 	@docker login -u $${DOCKER_USER} -p $${DOCKER_PASS}
@@ -55,7 +86,7 @@ release-dockerhub:
 	docker push objectrocket/opsy:latest
 
 release-pypi:
-	twine upload --non-interactive dist/Opsy-$(RELEASE_VERSION)-py3-none-any.whl dist/Opsy-$(RELEASE_VERSION).tar.gz
+	twine upload --non-interactive dist/python/Opsy-$(RELEASE_VERSION)-py3-none-any.whl dist/python/Opsy-$(RELEASE_VERSION).tar.gz
 
-release: release-test release-pypi release-dockerhub
+release: test-release release-pypi release-dockerhub
 

--- a/helm/opsy/Chart.yaml
+++ b/helm/opsy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: opsy
-appVersion: "0.3.1"
+appVersion: 0.0.1
 version: 0.0.1
 description: It's Opsy! A simple multi-user/role operations inventory system with aspirations.
 home: https://github.com/objectrocket/opsy

--- a/helm/opsy/templates/database_migration.yaml
+++ b/helm/opsy/templates/database_migration.yaml
@@ -15,54 +15,71 @@ spec:
       name: {{ include "opsy.fullname" . }}-database-migration
       labels:
         app: {{ include "opsy.fullname" . }}
+        app.kubernetes.io/name: {{ include "opsy.name" . }}
         app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
         app.kubernetes.io/instance: {{ .Release.Name | quote }}
         helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+      {{- range $key, $value := .Values.database_migration.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
     spec:
       restartPolicy: Never
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+      securityContext:
+        {{- toYaml .Values.database_migration.podSecurityContext | nindent 8 }}
       containers:
-      - name: {{ include "opsy.fullname" . }}-database-migration
-        image: "{{ .Values.image.repository }}:{{ include "opsy.imageTag" . }}"
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
-        envFrom:
-          - configMapRef:
-              name: {{ include "opsy.fullname" . }}-database-migrations
-        env:
-          - name: OPSY_MIGRATE_DB
-            value: "true"
-          - name: OPSY_CREATE_ADMIN_USER
-            value: "true"
-          - name: OPSY_RUN
-            value: "false"
-          - name: OPSY_ADMIN_PASSWORD
-            valueFrom:
-              secretKeyRef:
+        - name: {{ include "opsy.fullname" . }}-database-migration
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ include "opsy.imageTag" . }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          envFrom:
+            - configMapRef:
                 name: {{ include "opsy.fullname" . }}-database-migrations
-                key:  OPSY_ADMIN_PASSWORD
-          - name: OPSY_SECRET_KEY
-            valueFrom:
-              secretKeyRef:
-                name: {{ include "opsy.fullname" . }}-database-migrations
-                key:  OPSY_SECRET_KEY
-          - name: OPSY_DATABASE_URI
-            valueFrom:
-              secretKeyRef:
-                name: {{ include "opsy.fullname" . }}-database-migrations
-                key:  OPSY_DATABASE_URI
-          - name: OPSY_LDAP_BIND_USER_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: {{ include "opsy.fullname" . }}-database-migrations
-                key:  OPSY_LDAP_BIND_USER_PASSWORD
-        resources:
-{{ toYaml .Values.database_migration.resources | indent 12 }}
-        nodeSelector:
-{{ toYaml .Values.database_migration.nodeSelector | indent 12 }}
-        affinity:
-{{ toYaml .Values.database_migration.affinity | indent 12 }}
-        tolerations:
-{{ toYaml .Values.database_migration.tolerations | indent 12 }}
+          env:
+            - name: OPSY_MIGRATE_DB
+              value: "true"
+            - name: OPSY_CREATE_ADMIN_USER
+              value: "true"
+            - name: OPSY_RUN
+              value: "false"
+            - name: OPSY_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "opsy.fullname" . }}-database-migrations
+                  key:  OPSY_ADMIN_PASSWORD
+            - name: OPSY_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "opsy.fullname" . }}-database-migrations
+                  key:  OPSY_SECRET_KEY
+            - name: OPSY_DATABASE_URI
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "opsy.fullname" . }}-database-migrations
+                  key:  OPSY_DATABASE_URI
+            - name: OPSY_LDAP_BIND_USER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "opsy.fullname" . }}-database-migrations
+                  key:  OPSY_LDAP_BIND_USER_PASSWORD
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/helm/opsy/templates/deployment.yaml
+++ b/helm/opsy/templates/deployment.yaml
@@ -13,11 +13,17 @@ spec:
   template:
     metadata:
       labels:
+        app: {{ include "opsy.fullname" . }}
         app.kubernetes.io/name: {{ include "opsy.name" . }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+      {{- range $key, $value := .Values.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/helm/opsy/values.yaml
+++ b/helm/opsy/values.yaml
@@ -13,6 +13,8 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+podAnnotations: {}
+
 podSecurityContext: {}
   # fsGroup: 2000
 
@@ -80,6 +82,8 @@ opsy:
     ldap_group_search_scope: 'LEVEL'
 
 database_migration:
+  podAnnotations: {}
+  podSecurityContext: {}
   resources: {}
   nodeSelector: {}
   tolerations: {}

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,7 +6,7 @@ pylint==2.3.0
 pylint-flask==0.6
 pytest==5.0.1
 pytest-cov==2.7.1
-pytest-flask==0.15.0
+pytest-flask==0.15.1
 pytest-flask-sqlalchemy==1.0.2
 pytest-mock==1.11.0
 requests==2.22.0


### PR DESCRIPTION
Added linting and packaging for helm to makefile and circleci.

Added support for passing pod annotations as values to the helm chart.

Bumped pytest-flask to 0.15.1 to fix tests.

Updated dists/ to add sub directories since we're now building assets for python, docker and helm.

Added releasing helm to the gh-pages branch of this repo from circleci on tagged releases. This should create a public helm repo for Opsy at https://objectrocket.github.io/opsy/helm/.

Signed-off-by: M. David Bennett <m.david.bennett@rackspace.com>