### PR TITLE
Fix broken labels

### DIFF
--- a/helm/opsy/templates/_helpers.tpl
+++ b/helm/opsy/templates/_helpers.tpl
@@ -36,7 +36,7 @@ Common labels
 */}}
 {{- define "opsy.labels" -}}
 app.kubernetes.io/name: {{ include "opsy.name" . }}
-helm.sh/chart: {{ include "opsy.chart" . }}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
@@ -49,7 +49,7 @@ Migration labels
 */}}
 {{- define "opsy.migrationLabels" -}}
 app.kubernetes.io/name: {{ include "opsy.name" . }}-database-migrations
-helm.sh/chart: {{ include "opsy.chart" . }}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}

--- a/helm/opsy/templates/database_migration.yaml
+++ b/helm/opsy/templates/database_migration.yaml
@@ -14,7 +14,7 @@ spec:
     metadata:
       name: {{ include "opsy.fullname" . }}-database-migration
       labels:
-    {{ include "opsy.migrationLabels" . | indent 8 }}
+{{ include "opsy.migrationLabels" . | indent 8 }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}

--- a/helm/opsy/templates/database_migration.yaml
+++ b/helm/opsy/templates/database_migration.yaml
@@ -14,11 +14,7 @@ spec:
     metadata:
       name: {{ include "opsy.fullname" . }}-database-migration
       labels:
-        app: {{ include "opsy.fullname" . }}
-        app.kubernetes.io/name: {{ include "opsy.name" . }}
-        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-        app.kubernetes.io/instance: {{ .Release.Name | quote }}
-        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    {{ include "opsy.migrationLabels" . | indent 8 }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}

--- a/helm/opsy/templates/deployment.yaml
+++ b/helm/opsy/templates/deployment.yaml
@@ -13,11 +13,7 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ include "opsy.fullname" . }}
-        app.kubernetes.io/name: {{ include "opsy.name" . }}
-        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-        app.kubernetes.io/instance: {{ .Release.Name | quote }}
-        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    {{ include "opsy.labels" . | indent 8 }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}

--- a/helm/opsy/templates/deployment.yaml
+++ b/helm/opsy/templates/deployment.yaml
@@ -13,7 +13,7 @@ spec:
   template:
     metadata:
       labels:
-    {{ include "opsy.labels" . | indent 8 }}
+{{ include "opsy.labels" . | indent 8 }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}


### PR DESCRIPTION
Turns out k8s doesn't like having a plus "+" sign in labels, meaning I
need to convert the "+" sign in the version to a supported character.
This does that.

Signed-off-by: M. David Bennett <m.david.bennett@rackspace.com>