### PR TITLE
Add support for config through env vars to fix tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,6 +92,7 @@ jobs:
         environment:
           POSTGRES_USER: opsy
           POSTGRES_DB: opsy
+          POSTGRES_PASSWORD: $POSTGRES_PASSWORD
     working_directory: ~/repo
     steps:
       - setup_tox:
@@ -104,6 +105,7 @@ jobs:
         environment:
           POSTGRES_USER: opsy
           POSTGRES_DB: opsy
+          POSTGRES_PASSWORD: $POSTGRES_PASSWORD
     working_directory: ~/repo
     steps:
       - setup_tox:
@@ -116,6 +118,7 @@ jobs:
         environment:
           POSTGRES_USER: opsy
           POSTGRES_DB: opsy
+          POSTGRES_PASSWORD: $POSTGRES_PASSWORD
     working_directory: ~/repo
     steps:
       - setup_tox:

--- a/README.md
+++ b/README.md
@@ -95,6 +95,16 @@ Initialize the DB, the example config uses sqlite by default for development:
 
     $ opsyctl db upgrade
 
+# Running tests
+
+You can run the tests by running:
+
+    $ make test
+
+By default this will use a local sqlite database created at `tests/opsy.db` to run the tests. This can be changed by supplying a SQLAlchemy compatible database URI through the environment variable `OPSY_TEST_DATABASE_URI`:
+
+    $ OPSY_TEST_DATABASE_URI="postgresql://opsy:password@192.168.100.145/opsy" make test
+
 # Dealing with schema changes
 
 If you are introducing a change that requires a schema change you must create a schema revision. This can be done like so:

--- a/opsy/config.py
+++ b/opsy/config.py
@@ -3,6 +3,7 @@ import toml
 from marshmallow import (Schema, fields, validate, validates_schema,
                          ValidationError)
 from opsy.exceptions import NoConfigFile
+from opsy.utils import merge_dict
 
 
 class ConfigAppSchema(Schema):
@@ -84,12 +85,14 @@ class ConfigSchema(Schema):
         ConfigServerSchema(), missing=ConfigServerSchema().load({}))
 
 
-def load_config(config_file):
+def load_config(config_file, overrides=None):
     if not os.path.exists(config_file):
         raise NoConfigFile(f'File "{config_file}" does not exist.')
     with open(config_file, 'r') as file_handler:
-        config = ConfigSchema().load(toml.load(file_handler))
-    return config
+        config = toml.load(file_handler)
+    if overrides:
+        merge_dict(config, overrides)
+    return ConfigSchema().load(config)
 
 
 def configure_app(app, config):

--- a/opsy/server.py
+++ b/opsy/server.py
@@ -2,10 +2,12 @@ from cheroot import wsgi
 from cheroot.ssl.pyopenssl import pyOpenSSLAdapter
 
 
-def create_server(app, host, port, threads=10, ssl_enabled=None,
-                  certificate=None, private_key=None, ca_certificate=None):
-    server = wsgi.Server((host, port), app, numthreads=threads)
-    if ssl_enabled:
+def create_server(app):
+    server_config = app.config.opsy['server']
+    server = wsgi.Server((server_config['host'], server_config['port']), app,
+                         numthreads=server_config['threads'])
+    if server_config['ssl_enabled']:
         server.ssl_adapter = pyOpenSSLAdapter(
-            certificate, private_key, certificate_chain=ca_certificate)
+            server_config['certificate'], server_config['private_key'],
+            certificate_chain=server_config['ca_certificate'])
     return server

--- a/tests/app/test_app.py
+++ b/tests/app/test_app.py
@@ -55,12 +55,16 @@ def test_config(app):
     with pytest.raises(ValidationError, match=r'.*ssl_enabled.*'):
         load_config(
             f'{CURRENT_DIR}/../data/fake_opsy_config_no_ssl.toml')
+    # Make sure overrides work and don't remove non-overridden data.
+    overrides = {'app': {'database_uri': 'sqlite:///../opsy.db'}}
+    config = load_config(f'{CURRENT_DIR}/../test_opsy_config.toml',
+                         overrides=overrides)
+    assert config['app']['database_uri'] == overrides['app']['database_uri']
+    assert config['app']['secret_key'] == 'this should be changed'
     # Make sure our flask config makes it to the app.
     config = load_config(f'{CURRENT_DIR}/../test_opsy_config.toml')
     assert app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] is False
     assert app.config['SECRET_KEY'] == config['app']['secret_key']
-    assert app.config['SQLALCHEMY_DATABASE_URI'] == \
-        config['app']['database_uri']
 
 
 def test_logging(app, caplog):

--- a/tests/test_opsy_config.toml
+++ b/tests/test_opsy_config.toml
@@ -1,5 +1,6 @@
 [app]
-database_uri = 'postgresql://opsy@localhost/opsy'
+# Set to sqlite for local tests, can be set using env var OPSY_TEST_DATABASE_URI.
+database_uri = 'sqlite:///../tests/opsy.db'
 secret_key = 'this should be changed'
 
 [server]

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ deps =
     -r test-requirements.txt
 commands =
     pytest --cov=opsy --cov-report=term-missing
+passenv = OPSY_TEST_DATABASE_URI
 
 [pycodestyle]
 ignore = E402


### PR DESCRIPTION
Looks like the postgres image we use for tests has opinions about
running without a password. This is a quick fix to address that.

Signed-off-by: M. David Bennett <m.david.bennett@rackspace.com>