### PR TITLE
[PLAT-10861] Add docker authentication to avoid rate-limiting (redo)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,12 @@
 #
 version: 2.1
 
+references:
+  objectrocket-docker-auth: &objectrocket-docker-auth
+    auth:
+      username: ${DOCKER_USER}
+      password: ${DOCKER_PASS}
+
 workflows:
   version: 2
   # This will run on every commit, but not on tags.
@@ -79,6 +85,7 @@ jobs:
   test_style:
     docker:
       - image: circleci/python:3.6
+        <<: *objectrocket-docker-auth
     working_directory: ~/repo
     steps:
       - setup_tox:
@@ -88,7 +95,9 @@ jobs:
   test_python36:
     docker:
       - image: circleci/python:3.6
+        <<: *objectrocket-docker-auth
       - image: circleci/postgres:12
+        <<: *objectrocket-docker-auth
         environment:
           POSTGRES_USER: opsy
           POSTGRES_DB: opsy
@@ -101,7 +110,9 @@ jobs:
   test_python37:
     docker:
       - image: circleci/python:3.7
+        <<: *objectrocket-docker-auth
       - image: circleci/postgres:12
+        <<: *objectrocket-docker-auth
         environment:
           POSTGRES_USER: opsy
           POSTGRES_DB: opsy
@@ -114,7 +125,9 @@ jobs:
   test_python38:
     docker:
       - image: circleci/python:3.8
+        <<: *objectrocket-docker-auth
       - image: circleci/postgres:12
+        <<: *objectrocket-docker-auth
         environment:
           POSTGRES_USER: opsy
           POSTGRES_DB: opsy
@@ -127,6 +140,7 @@ jobs:
   build:
     docker:
       - image: circleci/python:3.6
+        <<: *objectrocket-docker-auth
     working_directory: ~/repo
     steps:
       - setup_helm
@@ -134,6 +148,7 @@ jobs:
   release:
     docker:
       - image: circleci/python:3.6
+        <<: *objectrocket-docker-auth
     working_directory: ~/repo
     steps:
       - setup_helm

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ marshmallow==3.2.1
 marshmallow-sqlalchemy==0.17.0
 pbr==5.1.1
 prometheus-flask-exporter==0.12.1
-psycopg2-binary==2.8.2
+psycopg2-binary==2.8.6
 pyOpenSSL==19.0.0
 python-dateutil==2.7.5
 stevedore==1.30.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,7 +4,7 @@ pycodestyle==2.4.0
 pydocstyle==3.0.0
 pylint==2.3.0
 pylint-flask==0.6
-pytest==5.0.1
+pytest==6.2.1
 pytest-cov==2.7.1
 pytest-flask==0.15.1
 pytest-flask-sqlalchemy==1.0.2


### PR DESCRIPTION
SUMMARY

FROM PLAT-10861
See: https://support.circleci.com/hc/en-us/articles/360050623311-Docker-Hub-rate-limiting-FAQ
Going forward best practice is to include docker authentication with all docker hub image pulls (even public images)

Manual redo of this since tests appear to be busted on the original PR.

Signed-off-by: M. David Bennett <m.david.bennett@rackspace.com>